### PR TITLE
Make pages align to the top

### DIFF
--- a/frontend/src/components/PageLayout.tsx
+++ b/frontend/src/components/PageLayout.tsx
@@ -6,7 +6,7 @@ interface PageLayoutProps {
 
 const PageLayout: React.FC<PageLayoutProps> = ({ children }) => {
   return (
-    <div className="min-h-full flex items-center justify-center p-4 sm:p-6 lg:p-8">
+    <div className="min-h-full flex items-start justify-center p-4 sm:p-6 lg:p-8">
       {children}
     </div>
   );


### PR DESCRIPTION
Align form pages to the top of the page for a more consistent experience as per #29. 