### PR TITLE
enable building openai images

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     strategy:
       matrix:
-        build_tags: [aws, ollama]
+        build_tags: [aws, ollama, openai]
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
As the integration is already done, it would be nice to have the image available for openai/nrp as well