### PR TITLE
Post-demo frontend fixes

### DIFF
--- a/frontend/src/components/FormContainer.tsx
+++ b/frontend/src/components/FormContainer.tsx
@@ -35,6 +35,7 @@ type PageState =
 const STORAGE_KEY = "justiceFormData";
 const PAGE_STATE_KEY = "justiceFormPageState";
 const TOS_ACCEPTED_TERMS_KEY = "justiceTosAccepted";
+const USER_LETTER_KEY = "justiceUserLetter";
 
 const INITIAL_FORM_DATA: FormData = {
   mainProblem: "",
@@ -96,7 +97,9 @@ const FormContainer = () => {
   const [location, setLocation] = useLocation();
   const previousLocation = usePreviousLocation();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [userLetter, setUserLetter] = useState<string>();
+  const [userLetter, setUserLetter] = useState<string | undefined>(() =>
+    loadFromLocalStorage(USER_LETTER_KEY, undefined),
+  );
 
   let direction = "normal";
   const locationOrder = [
@@ -128,6 +131,10 @@ const FormContainer = () => {
   useEffect(() => {
     saveToLocalStorage(TOS_ACCEPTED_TERMS_KEY, tosAcceptedHash);
   }, [tosAcceptedHash]);
+
+  useEffect(() => {
+    saveToLocalStorage(USER_LETTER_KEY, userLetter);
+  }, [userLetter]);
 
   const handleInputChange = (
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
@@ -223,10 +230,8 @@ const FormContainer = () => {
         <EditPage
           formData={formData}
           backPage="form3"
-          onChange={(e) => {
-            setUserLetter(e.target.value);
-          }}
           userLetter={userLetter}
+          setUserLetter={setUserLetter}
           animationDirection={direction}
           onSubmit={handlePageSubmit("addresses")}
         />

--- a/frontend/src/components/SubmittedPage.tsx
+++ b/frontend/src/components/SubmittedPage.tsx
@@ -194,7 +194,7 @@ const SubmittedPage: React.FC<SubmittedPageProps> = ({
         </a>
       )
     );
-  }, [pdf?.blobUrl]);
+  }, [pdf?.blobUrl, pdfWidth]);
 
   return (
     <PageLayout>
@@ -253,7 +253,7 @@ const SubmittedPage: React.FC<SubmittedPageProps> = ({
             {pdf && pdfElement}
             {pdfLoading && loadingSkeleton}
           </div>
-          <div className="flex w-full flex-wrap gap-2">
+          <div className="grid grid-cols-[180px_1fr] w-full gap-2">
             {/* Back Button */}
             <BackButton backPage={backPage} />
 
@@ -277,7 +277,7 @@ const SubmittedPage: React.FC<SubmittedPageProps> = ({
                 href={pdf.blobUrl}
                 target="_blank"
                 download={config.submittedPage.downloadFilename}
-                className="h-[52px] box-border bg-white border-2 border-border rounded-md font-semibold hover:bg-white hover:border-border-hover transition-all duration-200 uppercase text-sm sm:text-base align-middle flex items-center justify-center"
+                className="h-[52px] px-4 box-border bg-white border-2 border-border rounded-md font-semibold hover:bg-white hover:border-border-hover transition-all duration-200 uppercase text-sm sm:text-base align-middle flex items-center justify-center"
               >
                 {config.submittedPage.downloadButton}
               </a>


### PR DESCRIPTION
- Set user letter even if user doesn't edit
- Store user letter in local storage
- If you go back to the edit page, don't regenerate text
- If you go back to the edit page after deleting user letter from localStorage, causing captcha to fail, redirect to /form3
- Make download pdf button wider
- Fix pdf preview resizing (broken by #58)

Closes #82 
Closes #80 
Closes #81 

doesn’t fix #83 since I was unable to reproduce that on my parent’s MacBook
